### PR TITLE
build(deps): upgrade sdkms-client-go version

### DIFF
--- a/cmd/testSetup.go
+++ b/cmd/testSetup.go
@@ -140,9 +140,11 @@ func testSetup() {
 		ObjType: convertObjectType(objectTypeAES),
 		KeySize: someUint32(256),
 		Fpe: &sdkms.FpeOptions{
-			Radix:     16,
-			MinLength: 16,
-			MaxLength: 16 * 1024,
+			Basic: &sdkms.FpeOptionsBasic{
+				Radix:     16,
+				MinLength: 16,
+				MaxLength: 16 * 1024,
+			},
 		},
 	})
 
@@ -155,9 +157,10 @@ func testSetup() {
 		KeySize: someUint32(256),
 		KeyOps:  someKeyOps(sdkms.KeyOperationsEncrypt | sdkms.KeyOperationsDecrypt | sdkms.KeyOperationsWrapkey | sdkms.KeyOperationsUnwrapkey | sdkms.KeyOperationsHighvolume),
 		Fpe: &sdkms.FpeOptions{
-			Radix:     16,
-			MinLength: 16,
-			MaxLength: 16 * 1024,
+			Basic: &sdkms.FpeOptionsBasic{
+				Radix:     16,
+				MinLength: 16,
+				MaxLength: 16 * 1024},
 		},
 	})
 	checkErr("create high-volume AES key", err)
@@ -169,9 +172,10 @@ func testSetup() {
 		ObjType: convertObjectType(objectTypeAES),
 		KeySize: someUint32(192),
 		Fpe: &sdkms.FpeOptions{
-			Radix:     16,
-			MinLength: 16,
-			MaxLength: 16 * 1024,
+			Basic: &sdkms.FpeOptionsBasic{
+				Radix:     16,
+				MinLength: 16,
+				MaxLength: 16 * 1024},
 		},
 	})
 	checkErr("create AES key (192 bits)", err)
@@ -183,9 +187,10 @@ func testSetup() {
 		KeySize: someUint32(192),
 		KeyOps:  someKeyOps(sdkms.KeyOperationsEncrypt | sdkms.KeyOperationsDecrypt | sdkms.KeyOperationsWrapkey | sdkms.KeyOperationsUnwrapkey | sdkms.KeyOperationsHighvolume),
 		Fpe: &sdkms.FpeOptions{
-			Radix:     16,
-			MinLength: 16,
-			MaxLength: 16 * 1024,
+			Basic: &sdkms.FpeOptionsBasic{
+				Radix:     16,
+				MinLength: 16,
+				MaxLength: 16 * 1024},
 		},
 	})
 	checkErr("create high-volume AES key (192 bits)", err)

--- a/go.mod
+++ b/go.mod
@@ -2,14 +2,14 @@
 //
 //  This Source Code Form is subject to the terms of the Mozilla Public
 //  License, v. 2.0. If a copy of the MPL was not distributed with this
-//  file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+//  file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 module github.com/fortanix/dsm-perf-tool
 
 go 1.18
 
 require (
-	github.com/fortanix/sdkms-client-go v0.2.1
+	github.com/fortanix/sdkms-client-go v0.4.0
 	github.com/google/uuid v1.6.0
 	github.com/montanaflynn/stats v0.7.1
 	github.com/spf13/cobra v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
-github.com/fortanix/sdkms-client-go v0.2.1 h1:gT0QxwIgcHxZli1vt+Cfuo4nPVskCg0qh1yQ02OiTPw=
-github.com/fortanix/sdkms-client-go v0.2.1/go.mod h1:7df+XH9h8S/MDmF64sHKmDCBmrYqIi/8Ix72PVnRqfQ=
+github.com/fortanix/sdkms-client-go v0.4.0 h1:5cKiFJ4rzc69mhsVVI5Ma5ynr/k5vhvws0yfzfIro/k=
+github.com/fortanix/sdkms-client-go v0.4.0/go.mod h1:gjylIGX+6poVSe+JkbNsLTvseLd+rLjvcGFgXpW56Lo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=


### PR DESCRIPTION
- Upgrade sdkms-client-go version to latest `0.4.0`.
- Update code to sync up latest sdkms-client-go API.