### PR TITLE
Fix test-setup failed when creating FPE AES key

### DIFF
--- a/cmd/testSetup.go
+++ b/cmd/testSetup.go
@@ -156,7 +156,7 @@ func testSetup() {
 		GroupID: someString(group.GroupID),
 		ObjType: convertObjectType(objectTypeAES),
 		KeySize: someUint32(256),
-		KeyOps:  someKeyOps(sdkms.KeyOperationsEncrypt | sdkms.KeyOperationsDecrypt | sdkms.KeyOperationsWrapkey | sdkms.KeyOperationsUnwrapkey | sdkms.KeyOperationsHighvolume),
+		KeyOps:  someKeyOps(sdkms.KeyOperationsEncrypt | sdkms.KeyOperationsDecrypt | sdkms.KeyOperationsHighvolume),
 		Fpe: &sdkms.FpeOptions{
 			Basic: &sdkms.FpeOptionsBasic{
 				Radix:     16,
@@ -186,7 +186,7 @@ func testSetup() {
 		GroupID: someString(group.GroupID),
 		ObjType: convertObjectType(objectTypeAES),
 		KeySize: someUint32(192),
-		KeyOps:  someKeyOps(sdkms.KeyOperationsEncrypt | sdkms.KeyOperationsDecrypt | sdkms.KeyOperationsWrapkey | sdkms.KeyOperationsUnwrapkey | sdkms.KeyOperationsHighvolume),
+		KeyOps:  someKeyOps(sdkms.KeyOperationsEncrypt | sdkms.KeyOperationsDecrypt | sdkms.KeyOperationsHighvolume),
 		Fpe: &sdkms.FpeOptions{
 			Basic: &sdkms.FpeOptionsBasic{
 				Radix:     16,


### PR DESCRIPTION
This PR fix:
```
> go run . --insecure -s localhost -p 4443 test-setup --test-user test@fortanix.com --test-user-pwd sysadmin_password
2026/06/16 15:31:59 Failed to create high-volume AES key: Status: 400, Message: incompatible operation [WRAPKEY, UNWRAPKEY] for FPE key, allowed operations are [ENCRYPT, DECRYPT, EXPORT, APPMANAGEABLE, HIGHVOLUME]
exit status 1
```